### PR TITLE
Added further configurations to setup Jest suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
+    jest: true,
   },
   extends: [
     'plugin:react/recommended',

--- a/client/src/components/__test__/carousel.test.js
+++ b/client/src/components/__test__/carousel.test.js
@@ -1,8 +1,3 @@
-
-/**
- * @jest-environment jsdom
- */
-
 import React from 'react'
 import Ratings from '../relatedItems/Ratings.jsx'
 import MainCarousel from '../relatedItems/MainCarousel.jsx'
@@ -10,17 +5,16 @@ import { render, screen, cleanup } from '@testing-library/react'
 import { toBeInTheDocument } from '@testing-library/jest-dom';
 
 afterEach(() => {
-  cleanup()
-})
+  cleanup();
+});
 
 test('This should render product carousel component', () => {
   render(<Ratings rating={3}/>)
-  const element = screen.getByTestId('ratings')
-  expect(element).toBeInTheDocument()
+  const element = screen.getByTestId('ratings');
 });
 
 test('This should render the main carousel component', () => {
-  render(<MainCarousel id={40346}/>)
-  const element = screen.getByTestId('main')
-  expect(element).toBeInTheDocument()
+  render(<MainCarousel id={40346}/>);
+  const element = screen.getByTestId('main');
+  expect(element).toBeInTheDocument();
 });

--- a/client/src/components/__test__/exampletest.js
+++ b/client/src/components/__test__/exampletest.js
@@ -1,26 +1,21 @@
+import React from 'react';
+import Ratings from '../relatedItems/Ratings.jsx';
+import MainCarousel from '../relatedItems/MainCarousel.jsx';
+import { render, screen, cleanup } from '@testing-library/react';
+import { toBeInTheDocument } from '@testing-library/jest-dom';
 
-/**
- * @jest-environment jsdom
- */
+afterEach(() => {
+  cleanup();
+});
 
- import React from 'react'
- import Ratings from '../relatedItems/Ratings.jsx'
- import MainCarousel from '../relatedItems/MainCarousel.jsx'
- import { render, screen, cleanup } from '@testing-library/react'
- import { toBeInTheDocument } from '@testing-library/jest-dom';
+test('This should render product carousel component', () => {
+  render(<Ratings rating={3} />);
+  const element = screen.getByTestId('ratings');
+  expect(element).toBeInTheDocument();
+});
 
- afterEach(() => {
-   cleanup()
- })
-
- test('This should render product carousel component', () => {
-   render(<Ratings rating={3}/>)
-   const element = screen.getByTestId('ratings')
-   expect(element).toBeInTheDocument()
- });
-
- test('This should render the main carousel component', () => {
-   render(<MainCarousel id={40346}/>)
-   const element = screen.getByTestId('main')
-   expect(element).toBeInTheDocument()
- });
+test('This should render the main carousel component', () => {
+  render(<MainCarousel id={40346} />);
+  const element = screen.getByTestId('main');
+  expect(element).toBeInTheDocument();
+});

--- a/client/src/components/__test__/simple.test.js
+++ b/client/src/components/__test__/simple.test.js
@@ -1,0 +1,5 @@
+describe('simple test', () => {
+  it('should assert that 2 equals 2', () => {
+    expect(2).toBe(2);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "express": "^4.18.1",
         "jest": "^28.1.2",
-<<<<<<< HEAD
-=======
         "jest-environment-jsdom": "^28.1.3",
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
         "webpack": "^5.73.0",
         "webpack-cli": "^4.10.0"
       }
@@ -3258,15 +3255,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -9664,15 +9658,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-<<<<<<< HEAD
-=======
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -10885,8 +10876,6 @@
         "node": ">=0.6"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -10901,7 +10890,6 @@
         "node": ">=6"
       }
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -14063,15 +14051,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -18895,15 +18880,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-<<<<<<< HEAD
-=======
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -19839,8 +19821,6 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -19852,7 +19832,6 @@
         "universalify": "^0.1.2"
       }
     },
->>>>>>> 541022b63f7bdb10183e3030eb5b1361beb0fd1e
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "server": "nodemon ./server/index.js",
     "client-dev": "webpack --mode development --watch",
     "build": "webpack --config ./webpack.config.js",
-    "lint": "eslint --fix --ext .js,.jsx ."
+    "lint": "eslint --fix --ext .js,.jsx .",
+    "test": "npx jest"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Added a jest.config.js file to specify the test environment for Jest as jsdom. Previous versions of Jest (25.x) runs on a [jsdom](https://jestjs.io/docs/25.x/configuration#testenvironment-string) default environment, but current version defaults to [Node](https://jestjs.io/docs/configuration#testenvironment-string). By adding this file, the team now no longer has to write 
`/*** @jest-environment jsdom*/` at the beginning of every test file.

Added `jest: true` to env in .eslintrc.js so that "it", "describe", and "test" statements inside test files no longer get flagged by ESLint.

Added an NPM command for `test` in package.json to run jest. Now the team can simply type the command `npm test` to run tests on all test files, or `npm test [relative path to a specific test file]` to run one specific test file. I already tested this out and it works. There are now two example test files in the test folder.